### PR TITLE
Use hasOwnProperty to skip prototype properties

### DIFF
--- a/src/js-router.js
+++ b/src/js-router.js
@@ -203,6 +203,9 @@
                 // Iterating over route parameters
                 // and replacing them with input values.
                 for (var i in route.parameters) {
+                    if (!route.parameters.hasOwnProperty(i)) {
+                        continue;
+                    }
                     var parameterName = route.parameters[i];
 
                     if (typeof inputParameters[parameterName] == 'undefined') {


### PR DESCRIPTION
Same issue as the PR I did for `angular-router`: the `for in` loop is picking up added functions to the Array prototype, resulting in confusing errors.  
`hasOwnProperty` fixes this.
